### PR TITLE
feat: add file-based caching and fix crossfade timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Options:
   --seed N                 RNG seed for reproducibility
   --whisper-model MODEL    tiny/base/small/medium (default: base)
   --aligner MODE           auto/default/bfa (default: auto)
+  --no-cache               Disable file-based caching (re-run everything)
   -v, --verbose            Show all dependency warnings (default: quiet)
 
 Prosodic grouping:
@@ -138,6 +139,7 @@ Options:
   --seed N                 RNG seed for reproducibility
   --whisper-model MODEL    tiny/base/small/medium (default: base)
   --drift-range SEMI       Max pitch drift from melody (default: 2.0)
+  --no-cache               Disable file-based caching (re-run everything)
   --vibrato / --no-vibrato (default: on)
   --chorus / --no-chorus   (default: on)
 ```
@@ -189,6 +191,32 @@ glottisdale collage input.mp4 --aligner bfa
 ```
 
 The `--aligner auto` mode (default) tries BFA first and falls back to the default aligner if BFA is not installed.
+
+## Caching
+
+Glottisdale caches expensive intermediate results to speed up repeated runs on the same files. Caches are stored in `~/.cache/glottisdale/` with three tiers:
+
+| Tier | Directory | What's cached |
+|------|-----------|---------------|
+| Audio extraction | `extract/` | 16kHz mono WAV resampled from input |
+| Whisper transcription | `whisper/` | Word-level timestamps and transcript |
+| Alignment | `align/` | Syllable/phoneme-level timestamps |
+
+Cache keys are derived from the SHA-256 hash of the input file, plus the Whisper model and aligner settings. A second run on the same input files skips extraction (~seconds), transcription (~5-10 min), and alignment (~1-3 min).
+
+To bypass the cache and re-process everything:
+
+```bash
+glottisdale collage input.mp4 --no-cache
+```
+
+To clear the cache entirely:
+
+```bash
+rm -rf ~/.cache/glottisdale/
+```
+
+You can override the cache location with the `GLOTTISDALE_CACHE_DIR` environment variable.
 
 ## License
 

--- a/src/glottisdale/cache.py
+++ b/src/glottisdale/cache.py
@@ -1,0 +1,194 @@
+"""File-based caching for expensive pipeline operations."""
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from glottisdale.types import Phoneme, Syllable
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIR = Path(os.environ.get("GLOTTISDALE_CACHE_DIR", "~/.cache/glottisdale")).expanduser()
+
+
+def file_hash(path: Path) -> str:
+    """Compute SHA-256 hash of a file's contents."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _atomic_write(target: Path, data: bytes) -> None:
+    """Write data to target atomically via temp file + rename."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=target.parent, suffix=".tmp")
+    try:
+        os.write(fd, data)
+        os.close(fd)
+        os.replace(tmp, target)
+    except Exception:
+        os.close(fd) if not os.get_inheritable(fd) else None
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+# --- Audio extraction cache ---
+
+
+def _extract_cache_path(input_hash: str) -> Path:
+    return CACHE_DIR / "extract" / f"{input_hash}.wav"
+
+
+def get_cached_audio(input_hash: str) -> Path | None:
+    """Return cached extracted audio path, or None if not cached."""
+    path = _extract_cache_path(input_hash)
+    if path.exists() and path.stat().st_size > 0:
+        logger.info(f"Cache hit: audio extraction ({input_hash[:12]}...)")
+        return path
+    return None
+
+
+def store_audio_cache(input_hash: str, audio_path: Path) -> Path:
+    """Copy extracted audio into cache. Returns the cache path."""
+    dest = _extract_cache_path(input_hash)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(audio_path, dest)
+    logger.info(f"Cached audio extraction ({input_hash[:12]}...)")
+    return dest
+
+
+# --- Whisper transcription cache ---
+
+
+def _whisper_cache_path(audio_hash: str, model: str, language: str) -> Path:
+    return CACHE_DIR / "whisper" / f"{audio_hash}_{model}_{language}.json"
+
+
+def get_cached_transcription(
+    audio_hash: str, model: str, language: str
+) -> dict | None:
+    """Return cached whisper result dict, or None if not cached."""
+    path = _whisper_cache_path(audio_hash, model, language)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            logger.info(f"Cache hit: transcription ({audio_hash[:12]}...)")
+            return data
+        except (json.JSONDecodeError, OSError):
+            return None
+    return None
+
+
+def store_transcription_cache(
+    audio_hash: str, model: str, language: str, result: dict
+) -> None:
+    """Store whisper transcription result in cache."""
+    path = _whisper_cache_path(audio_hash, model, language)
+    _atomic_write(path, json.dumps(result).encode())
+    logger.info(f"Cached transcription ({audio_hash[:12]}...)")
+
+
+# --- Alignment cache ---
+
+
+def _align_cache_path(
+    aligner_name: str,
+    audio_hash: str,
+    model: str,
+    language: str,
+    device: str | None = None,
+) -> Path:
+    parts = [aligner_name, audio_hash, model, language]
+    if device:
+        parts.append(device)
+    return CACHE_DIR / "align" / f"{'_'.join(parts)}.json"
+
+
+def _serialize_alignment(result: dict) -> dict:
+    """Convert alignment result (with Syllable/Phoneme objects) to JSON-safe dict."""
+    serialized = {
+        "text": result["text"],
+        "words": result["words"],
+        "syllables": [
+            {
+                "phonemes": [
+                    {"label": p.label, "start": p.start, "end": p.end}
+                    for p in syl.phonemes
+                ],
+                "start": syl.start,
+                "end": syl.end,
+                "word": syl.word,
+                "word_index": syl.word_index,
+            }
+            for syl in result["syllables"]
+        ],
+    }
+    return serialized
+
+
+def _deserialize_alignment(data: dict) -> dict:
+    """Reconstruct Syllable/Phoneme objects from cached JSON."""
+    syllables = []
+    for syl_data in data.get("syllables", []):
+        phonemes = [
+            Phoneme(
+                label=p["label"],
+                start=p["start"],
+                end=p["end"],
+            )
+            for p in syl_data["phonemes"]
+        ]
+        syllables.append(Syllable(
+            phonemes=phonemes,
+            start=syl_data["start"],
+            end=syl_data["end"],
+            word=syl_data["word"],
+            word_index=syl_data["word_index"],
+        ))
+    return {
+        "text": data["text"],
+        "words": data["words"],
+        "syllables": syllables,
+    }
+
+
+def get_cached_alignment(
+    aligner_name: str,
+    audio_hash: str,
+    model: str,
+    language: str,
+    device: str | None = None,
+) -> dict | None:
+    """Return cached alignment result with deserialized Syllable objects, or None."""
+    path = _align_cache_path(aligner_name, audio_hash, model, language, device)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            result = _deserialize_alignment(data)
+            logger.info(f"Cache hit: alignment ({audio_hash[:12]}...)")
+            return result
+        except (json.JSONDecodeError, OSError, KeyError):
+            return None
+    return None
+
+
+def store_alignment_cache(
+    aligner_name: str,
+    audio_hash: str,
+    model: str,
+    language: str,
+    result: dict,
+    device: str | None = None,
+) -> None:
+    """Store alignment result in cache."""
+    path = _align_cache_path(aligner_name, audio_hash, model, language, device)
+    serialized = _serialize_alignment(result)
+    _atomic_write(path, json.dumps(serialized).encode())
+    logger.info(f"Cached alignment ({audio_hash[:12]}...)")

--- a/src/glottisdale/cli.py
+++ b/src/glottisdale/cli.py
@@ -24,6 +24,8 @@ def _add_shared_args(parser: argparse.ArgumentParser) -> None:
                         help="RNG seed for reproducible output")
     parser.add_argument("-v", "--verbose", action="store_true", default=False,
                         help="Show all warnings from dependencies (default: quiet)")
+    parser.add_argument("--no-cache", action="store_true", default=False,
+                        help="Disable file-based caching of extraction, transcription, and alignment")
 
 
 def _add_collage_args(parser: argparse.ArgumentParser) -> None:
@@ -226,6 +228,7 @@ def _run_collage(args: argparse.Namespace) -> None:
         stutter=args.stutter,
         stutter_count=args.stutter_count,
         verbose=args.verbose,
+        use_cache=not args.no_cache,
     )
 
     print(f"Processed {len(args.input_files)} source file(s)")
@@ -272,7 +275,10 @@ def _run_sing(args: argparse.Namespace) -> None:
 
     # Prepare syllables from audio files
     logger.info(f"Preparing syllables from {len(input_paths)} audio file(s)")
-    syllables = prepare_syllables(input_paths, work_dir, args.whisper_model)
+    syllables = prepare_syllables(
+        input_paths, work_dir, args.whisper_model,
+        use_cache=not args.no_cache,
+    )
     logger.info(f"Prepared {len(syllables)} syllables")
 
     # Compute median F0

--- a/src/glottisdale/collage/transcribe.py
+++ b/src/glottisdale/collage/transcribe.py
@@ -1,8 +1,11 @@
 """Whisper ASR transcription with word-level timestamps."""
 
+import logging
 from pathlib import Path
 
 import whisper
+
+logger = logging.getLogger(__name__)
 
 _model_cache: dict[str, object] = {}
 
@@ -11,8 +14,17 @@ def transcribe(
     audio_path: Path,
     model_name: str = "base",
     language: str = "en",
+    audio_hash: str | None = None,
+    use_cache: bool = False,
 ) -> dict:
     """Transcribe audio and return word-level timestamps.
+
+    Args:
+        audio_path: Path to the audio file.
+        model_name: Whisper model size.
+        language: Language code.
+        audio_hash: Pre-computed hash of the audio file (enables caching).
+        use_cache: Whether to check/store the transcription cache.
 
     Returns:
         Dict with keys:
@@ -20,6 +32,12 @@ def transcribe(
             words: List of dicts with 'word', 'start', 'end' keys
             language: Detected or specified language
     """
+    if use_cache and audio_hash:
+        from glottisdale.cache import get_cached_transcription
+        cached = get_cached_transcription(audio_hash, model_name, language)
+        if cached is not None:
+            return cached
+
     if model_name not in _model_cache:
         _model_cache[model_name] = whisper.load_model(model_name)
     model = _model_cache[model_name]
@@ -40,8 +58,14 @@ def transcribe(
                 "end": w["end"],
             })
 
-    return {
+    output = {
         "text": result["text"].strip(),
         "words": words,
         "language": result.get("language", language),
     }
+
+    if use_cache and audio_hash:
+        from glottisdale.cache import store_transcription_cache
+        store_transcription_cache(audio_hash, model_name, language, output)
+
+    return output

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,213 @@
+"""Tests for the cache module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from glottisdale.cache import (
+    file_hash,
+    get_cached_audio,
+    store_audio_cache,
+    get_cached_transcription,
+    store_transcription_cache,
+    get_cached_alignment,
+    store_alignment_cache,
+    _serialize_alignment,
+    _deserialize_alignment,
+)
+from glottisdale.types import Phoneme, Syllable
+
+
+@pytest.fixture(autouse=True)
+def isolated_cache(tmp_path, monkeypatch):
+    """Redirect cache to tmp_path so tests don't pollute the real cache."""
+    monkeypatch.setattr("glottisdale.cache.CACHE_DIR", tmp_path / "cache")
+
+
+# --- file_hash ---
+
+
+def test_file_hash_deterministic(tmp_path):
+    """Same content always produces the same hash."""
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"hello world")
+    h1 = file_hash(f)
+    h2 = file_hash(f)
+    assert h1 == h2
+    assert len(h1) == 64  # SHA-256 hex
+
+
+def test_file_hash_different_content(tmp_path):
+    """Different content produces different hashes."""
+    f1 = tmp_path / "a.bin"
+    f2 = tmp_path / "b.bin"
+    f1.write_bytes(b"hello")
+    f2.write_bytes(b"world")
+    assert file_hash(f1) != file_hash(f2)
+
+
+# --- Audio extraction cache ---
+
+
+def test_audio_cache_miss():
+    assert get_cached_audio("nonexistent_hash") is None
+
+
+def test_audio_cache_roundtrip(tmp_path):
+    """Store and retrieve extracted audio."""
+    wav = tmp_path / "test.wav"
+    wav.write_bytes(b"RIFF" + b"\x00" * 100)
+
+    path = store_audio_cache("abc123", wav)
+    assert path.exists()
+
+    cached = get_cached_audio("abc123")
+    assert cached is not None
+    assert cached.read_bytes() == wav.read_bytes()
+
+
+# --- Whisper transcription cache ---
+
+
+def test_transcription_cache_miss():
+    assert get_cached_transcription("hash", "base", "en") is None
+
+
+def test_transcription_cache_roundtrip():
+    result = {
+        "text": "hello world",
+        "words": [
+            {"word": "hello", "start": 0.0, "end": 0.5},
+            {"word": "world", "start": 0.6, "end": 1.0},
+        ],
+        "language": "en",
+    }
+    store_transcription_cache("audio_hash", "base", "en", result)
+    cached = get_cached_transcription("audio_hash", "base", "en")
+    assert cached is not None
+    assert cached["text"] == "hello world"
+    assert len(cached["words"]) == 2
+    assert cached["words"][0]["word"] == "hello"
+
+
+def test_transcription_cache_different_model():
+    """Different model names produce different cache entries."""
+    result = {"text": "hi", "words": [], "language": "en"}
+    store_transcription_cache("hash", "base", "en", result)
+    store_transcription_cache("hash", "small", "en", {"text": "different", "words": [], "language": "en"})
+
+    base = get_cached_transcription("hash", "base", "en")
+    small = get_cached_transcription("hash", "small", "en")
+    assert base["text"] == "hi"
+    assert small["text"] == "different"
+
+
+# --- Alignment cache ---
+
+
+def _make_alignment_result():
+    """Create a sample alignment result with Syllable/Phoneme objects."""
+    return {
+        "text": "hello world",
+        "words": [
+            {"word": "hello", "start": 0.0, "end": 0.5},
+            {"word": "world", "start": 0.6, "end": 1.0},
+        ],
+        "syllables": [
+            Syllable(
+                phonemes=[
+                    Phoneme(label="HH", start=0.0, end=0.1),
+                    Phoneme(label="AH0", start=0.1, end=0.25),
+                ],
+                start=0.0,
+                end=0.25,
+                word="hello",
+                word_index=0,
+            ),
+            Syllable(
+                phonemes=[
+                    Phoneme(label="L", start=0.25, end=0.35),
+                    Phoneme(label="OW1", start=0.35, end=0.5),
+                ],
+                start=0.25,
+                end=0.5,
+                word="hello",
+                word_index=0,
+            ),
+            Syllable(
+                phonemes=[
+                    Phoneme(label="W", start=0.6, end=0.7),
+                    Phoneme(label="ER1", start=0.7, end=0.85),
+                    Phoneme(label="L", start=0.85, end=0.9),
+                    Phoneme(label="D", start=0.9, end=1.0),
+                ],
+                start=0.6,
+                end=1.0,
+                word="world",
+                word_index=1,
+            ),
+        ],
+    }
+
+
+def test_alignment_cache_miss():
+    assert get_cached_alignment("default", "hash", "base", "en") is None
+
+
+def test_alignment_cache_roundtrip():
+    result = _make_alignment_result()
+    store_alignment_cache("default", "audio_hash", "base", "en", result)
+    cached = get_cached_alignment("default", "audio_hash", "base", "en")
+
+    assert cached is not None
+    assert cached["text"] == "hello world"
+    assert len(cached["words"]) == 2
+    assert len(cached["syllables"]) == 3
+
+
+def test_alignment_deserializes_syllable_objects():
+    """Cached alignment should produce real Syllable/Phoneme dataclass instances."""
+    result = _make_alignment_result()
+    store_alignment_cache("bfa", "hash", "base", "en", result, device="cpu")
+    cached = get_cached_alignment("bfa", "hash", "base", "en", device="cpu")
+
+    assert cached is not None
+    syls = cached["syllables"]
+    assert all(isinstance(s, Syllable) for s in syls)
+    assert all(isinstance(p, Phoneme) for p in syls[0].phonemes)
+
+    # Verify values roundtrip correctly
+    assert syls[0].word == "hello"
+    assert syls[0].word_index == 0
+    assert syls[0].start == 0.0
+    assert syls[0].end == 0.25
+    assert syls[0].phonemes[0].label == "HH"
+    assert syls[0].phonemes[0].start == 0.0
+    assert syls[0].phonemes[0].end == 0.1
+
+    assert syls[2].word == "world"
+    assert syls[2].word_index == 1
+    assert len(syls[2].phonemes) == 4
+
+
+def test_alignment_cache_different_aligner():
+    """Different aligner names produce different cache entries."""
+    result = _make_alignment_result()
+    store_alignment_cache("default", "hash", "base", "en", result)
+    assert get_cached_alignment("bfa", "hash", "base", "en") is None
+
+
+def test_serialize_deserialize_roundtrip():
+    """Direct test of serialization/deserialization."""
+    result = _make_alignment_result()
+    serialized = _serialize_alignment(result)
+
+    # Serialized should be JSON-safe (no dataclass objects)
+    json_str = json.dumps(serialized)
+    assert "HH" in json_str
+
+    deserialized = _deserialize_alignment(serialized)
+    assert len(deserialized["syllables"]) == 3
+    assert isinstance(deserialized["syllables"][0], Syllable)
+    assert isinstance(deserialized["syllables"][0].phonemes[0], Phoneme)


### PR DESCRIPTION
## Summary

- **File-based caching** for Whisper transcription, BFA alignment, and audio extraction in `~/.cache/glottisdale/` — second runs on the same files skip the expensive steps (~5-15 min saved)
- **Crossfade timeout fix** — batch acrossfade in groups of 8 and increase subprocess timeout from 120s to 600s, preventing timeouts when stutter/repeat creates words with 16+ syllable clips
- **`--no-cache` CLI flag** to bypass caching on both `collage` and `sing` subcommands

## Test plan

- [x] `uv run pytest` — 239 tests pass (12 new)
- [ ] Run collage on test files twice — second run should be fast (cache hit logs)
- [ ] Run with `--no-cache` — should re-process everything
- [ ] Run with 16+ stutter clips — should not timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)