### PR TITLE
Add GUI binary to releases, bump to v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,22 +30,33 @@ jobs:
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg libasound2-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libasound2-dev \
+            libxkbcommon-dev libgtk-3-dev
 
-      - name: Build release binary
+      - name: Build release binaries
         run: cargo build --release
 
-      - name: Package CLI binary
+      - name: Package binaries
         run: |
           mkdir -p dist
           cp target/release/glottisdale dist/glottisdale-${{ matrix.binary_suffix }}
+          cp target/release/glottisdale-gui dist/glottisdale-gui-${{ matrix.binary_suffix }}
           chmod +x dist/glottisdale-${{ matrix.binary_suffix }}
+          chmod +x dist/glottisdale-gui-${{ matrix.binary_suffix }}
 
-      - name: Upload artifact
+      - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:
           name: glottisdale-${{ matrix.binary_suffix }}
           path: dist/glottisdale-${{ matrix.binary_suffix }}
+
+      - name: Upload GUI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: glottisdale-gui-${{ matrix.binary_suffix }}
+          path: dist/glottisdale-gui-${{ matrix.binary_suffix }}
 
   release:
     needs: build
@@ -60,5 +71,5 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/*/glottisdale-*
+          files: artifacts/*/glottisdale*
           generate_release_notes: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/cli", "crates/gui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,15 @@ cargo build --release
 Download from [GitHub Releases](https://github.com/A-U-Supply/glottisdale/releases):
 
 ```bash
-# Linux
+# Linux (CLI + GUI)
 curl -L https://github.com/A-U-Supply/glottisdale/releases/latest/download/glottisdale-linux-amd64 -o glottisdale
-chmod +x glottisdale && sudo mv glottisdale /usr/local/bin/
+curl -L https://github.com/A-U-Supply/glottisdale/releases/latest/download/glottisdale-gui-linux-amd64 -o glottisdale-gui
+chmod +x glottisdale glottisdale-gui && sudo mv glottisdale glottisdale-gui /usr/local/bin/
 
-# macOS (Apple Silicon)
+# macOS (Apple Silicon, CLI + GUI)
 curl -L https://github.com/A-U-Supply/glottisdale/releases/latest/download/glottisdale-darwin-arm64 -o glottisdale
-chmod +x glottisdale && sudo mv glottisdale /usr/local/bin/
+curl -L https://github.com/A-U-Supply/glottisdale/releases/latest/download/glottisdale-gui-darwin-arm64 -o glottisdale-gui
+chmod +x glottisdale glottisdale-gui && sudo mv glottisdale glottisdale-gui /usr/local/bin/
 ```
 
 Also requires ffmpeg and [Whisper](https://github.com/openai/whisper) (`pip install openai-whisper`).

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -81,14 +81,15 @@ On other distributions, use your package manager's equivalent (e.g., `dnf instal
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/A-U-Supply/glottisdale/releases):
 
-- **Linux (x86_64):** `glottisdale-linux-amd64`
-- **macOS (Apple Silicon):** `glottisdale-darwin-arm64`
+- **Linux (x86_64):** `glottisdale-linux-amd64` + `glottisdale-gui-linux-amd64`
+- **macOS (Apple Silicon):** `glottisdale-darwin-arm64` + `glottisdale-gui-darwin-arm64`
 
-Make it executable and move it somewhere on your PATH:
+Make them executable and move them somewhere on your PATH:
 
 ```bash
-chmod +x glottisdale-*
+chmod +x glottisdale-* glottisdale-gui-*
 sudo mv glottisdale-* /usr/local/bin/glottisdale
+sudo mv glottisdale-gui-* /usr/local/bin/glottisdale-gui
 ```
 
 ### From source


### PR DESCRIPTION
## Summary
- Add `glottisdale-gui` binary to the release workflow (Linux x86_64 + macOS ARM64)
- Install Linux system deps for eframe/egui (libxkbcommon-dev, libgtk-3-dev)
- Bump workspace version to 0.2.0
- Update README and install docs with GUI download instructions

## Test plan
- [ ] Verify CI passes
- [ ] Tag v0.2.0 after merge to trigger release build
- [ ] Verify release includes both CLI and GUI binaries for both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)