### PR TITLE
chore: final verification and docs for playback fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,10 @@ After running any pipeline, click **"Edit Arrangement"** to open the interactive
 
 The editor provides:
 
-- **Syllable bank** — all aligned syllables from your source audio, filterable, with waveform previews. Click to add to the timeline, double-click to preview.
+- **Syllable bank** — all aligned syllables from your source audio, filterable, with waveform previews. Click to add to the timeline; each entry has a ▶ play button for quick preview.
 - **Timeline** — drag-to-reorder clips, zoom/pan (Ctrl+scroll / scroll), click to select, Shift+click for multi-select.
 - **Effects** — right-click any clip for stutter (x2-x8), time stretch (0.5x-4x), pitch shift (-12 to +12 semitones), duplicate, delete, and clear effects.
-- **Playback** — Play/Pause/Stop with a moving cursor. Plays from cursor position.
+- **Playback** — Play/Pause/Stop with a moving cursor. Plays from cursor position. Errors display as red text in the toolbar with a dismiss button.
 - **Export** — render the arrangement to a WAV file.
 
 ## Dependencies

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Syllable-level audio collage
-    Collage(CollageArgs),
+    Collage(Box<CollageArgs>),
     /// Map syllables to MIDI melody ("drunk choir")
     Sing(SingArgs),
     /// Reconstruct text using source audio syllables
@@ -325,7 +325,7 @@ fn main() {
         .init();
 
     let result = match cli.command {
-        Command::Collage(args) => run_collage(args),
+        Command::Collage(args) => run_collage(*args),
         Command::Sing(args) => run_sing(args),
         Command::Speak(args) => run_speak(args),
     };

--- a/crates/core/src/collage/process.rs
+++ b/crates/core/src/collage/process.rs
@@ -610,7 +610,7 @@ pub fn process(
         write_wav(&word_output, &word_samples, sr)?;
 
         // Determine dominant source
-        let word_sources: Vec<String> = word_syls.iter().map(|s| find_source(s)).collect();
+        let word_sources: Vec<String> = word_syls.iter().map(&find_source).collect();
         let dominant = word_sources
             .iter()
             .max_by_key(|s| word_sources.iter().filter(|t| *t == *s).count())

--- a/crates/core/src/collage/stretch.rs
+++ b/crates/core/src/collage/stretch.rs
@@ -80,7 +80,7 @@ pub fn should_stretch_syllable(
     }
 
     if let Some(n) = config.alternating_stretch {
-        if n > 0 && syllable_index % n == 0 {
+        if n > 0 && syllable_index.is_multiple_of(n) {
             return true;
         }
     }

--- a/crates/core/src/editor/pipeline_bridge.rs
+++ b/crates/core/src/editor/pipeline_bridge.rs
@@ -1,7 +1,7 @@
 //! Convert pipeline output to editor arrangements.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
@@ -41,7 +41,7 @@ pub fn arrangement_from_collage(
         for (source, idx) in indices {
             // Find matching bank clip by source path and syllable index
             if let Some(bank_clip) = bank.iter().find(|c| {
-                c.source_path == PathBuf::from(source)
+                c.source_path == Path::new(source)
                     && c.syllable.word_index == *idx
             }) {
                 arr.timeline.push(TimelineClip::new(bank_clip));

--- a/crates/core/src/editor/playback_engine.rs
+++ b/crates/core/src/editor/playback_engine.rs
@@ -33,6 +33,12 @@ pub struct PlaybackState {
     pub last_error: Arc<Mutex<Option<String>>>,
 }
 
+impl Default for PlaybackState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PlaybackState {
     pub fn new() -> Self {
         Self {
@@ -68,6 +74,12 @@ impl PlaybackState {
 pub struct PlaybackEngine {
     command_tx: mpsc::Sender<PlaybackCommand>,
     pub state: PlaybackState,
+}
+
+impl Default for PlaybackEngine {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PlaybackEngine {

--- a/crates/core/src/language/phonotactics.rs
+++ b/crates/core/src/language/phonotactics.rs
@@ -102,7 +102,7 @@ fn ipa_sonority(label: &str) -> i32 {
         return 7;
     }
     let first = label.chars().next().unwrap();
-    let stripped = label.trim_end_matches(|c: char| c == 'ː' || c == 'ˑ');
+    let stripped = label.trim_end_matches(['ː', 'ˑ']);
     if IPA_VOWELS.contains(&first) || (stripped.len() == 1 && IPA_VOWELS.contains(&stripped.chars().next().unwrap_or(' '))) {
         return 7;
     }

--- a/crates/core/src/language/syllabify_arpabet.rs
+++ b/crates/core/src/language/syllabify_arpabet.rs
@@ -108,7 +108,7 @@ pub fn syllabify(pron: &[String], alaska_rule: bool) -> Result<Vec<SyllableParts
         }
 
         // Y-gliding: if onset ends with Y and has >2 consonants, push Y into next nucleus
-        if onsets[i].len() > 2 && onsets[i].last().map_or(false, |s| s == "Y") {
+        if onsets[i].len() > 2 && onsets[i].last().is_some_and(|s| s == "Y") {
             let y = onsets[i].pop().unwrap();
             nuclei[i].insert(0, y);
         }
@@ -116,7 +116,7 @@ pub fn syllabify(pron: &[String], alaska_rule: bool) -> Result<Vec<SyllableParts
         // Alaska rule: /s/ before lax vowels goes to coda
         if onsets[i].len() > 1
             && alaska_rule
-            && nuclei[i - 1].last().map_or(false, |s| is_slax(s))
+            && nuclei[i - 1].last().is_some_and(|s| is_slax(s))
             && onsets[i][0] == "S"
         {
             coda.push(onsets[i].remove(0));
@@ -157,8 +157,8 @@ pub fn syllabify(pron: &[String], alaska_rule: bool) -> Result<Vec<SyllableParts
     // Build output
     let output: Vec<SyllableParts> = onsets
         .into_iter()
-        .zip(nuclei.into_iter())
-        .zip(codas.into_iter())
+        .zip(nuclei)
+        .zip(codas)
         .map(|((o, n), c)| (o, n, c))
         .collect();
 

--- a/crates/core/src/language/transcribe.rs
+++ b/crates/core/src/language/transcribe.rs
@@ -20,7 +20,7 @@ pub fn transcribe(
 ) -> Result<TranscriptionResult> {
     #[cfg(feature = "whisper-native")]
     {
-        return transcribe_native(audio_path, model_name, language, model_dir);
+        transcribe_native(audio_path, model_name, language, model_dir)
     }
 
     #[cfg(not(feature = "whisper-native"))]

--- a/crates/core/src/sing/mixer.rs
+++ b/crates/core/src/sing/mixer.rs
@@ -48,7 +48,7 @@ pub fn mix_tracks(
         let mut midi = midi_samples;
         // Resample MIDI to match vocal sample rate if needed
         // (synthesizer outputs at 22050, vocals at 16000)
-        if midi.len() > 0 {
+        if !midi.is_empty() {
             let midi_sr = 22050; // from synthesizer
             if midi_sr != vocal_sr {
                 if let Ok(resampled) = crate::audio::io::resample(&midi, midi_sr, vocal_sr) {

--- a/crates/core/src/sing/vocal_mapper.rs
+++ b/crates/core/src/sing/vocal_mapper.rs
@@ -209,12 +209,10 @@ pub fn render_mapping(
     }
 
     let mut rendered_parts: Vec<Vec<f64>> = Vec::new();
-
-    for (_i, (&syl_idx, &syl_dur)) in mapping
+    for (&syl_idx, &syl_dur) in mapping
         .syllable_indices
         .iter()
         .zip(syl_durations.iter())
-        .enumerate()
     {
         if syl_idx >= syllable_clips.len() {
             continue;

--- a/crates/core/src/speak/assembler.rs
+++ b/crates/core/src/speak/assembler.rs
@@ -187,6 +187,7 @@ fn normalize_pitch_clips(clips: &mut [Vec<f64>], sr: u32, pitch_range: f64) {
 ///
 /// Consecutive matches from adjacent positions in the same source file
 /// are cut as a single clip to preserve natural coarticulation.
+#[allow(clippy::too_many_arguments)]
 pub fn assemble(
     matches: &[MatchResult],
     timing: &[TimingPlan],

--- a/crates/core/src/speak/matcher.rs
+++ b/crates/core/src/speak/matcher.rs
@@ -101,7 +101,7 @@ pub fn match_syllables(
     // parents[i][j] = bank index chosen for target i-1 on the best path to j
     let mut parents: Vec<Vec<usize>> = vec![vec![0; b]]; // placeholder for i=0
 
-    for i in 1..n {
+    for dist_row in dists.iter().take(n).skip(1) {
         let mut new_dp = vec![inf; b];
         let mut new_parent = vec![0usize; b];
 
@@ -113,7 +113,7 @@ pub fn match_syllables(
             .unwrap();
 
         for j in 0..b {
-            let cost = dists[i][j];
+            let cost = dist_row[j];
 
             // Non-contiguous: best of any previous bank entry
             let mut best = min_prev + cost;

--- a/crates/core/src/speak/phonetic_distance.rs
+++ b/crates/core/src/speak/phonetic_distance.rs
@@ -95,7 +95,7 @@ pub fn normalize_phoneme(phoneme: &str) -> String {
     }
 
     // Strip IPA length markers
-    let cleaned = phoneme.trim_end_matches(|c: char| c == 'ː' || c == 'ˑ');
+    let cleaned = phoneme.trim_end_matches(['ː', 'ˑ']);
 
     // Try multi-char diphthongs first, then single-char
     for (ipa, arpabet) in IPA_TO_ARPABET.iter() {

--- a/crates/gui/src/app.rs
+++ b/crates/gui/src/app.rs
@@ -303,8 +303,7 @@ fn load_texture(
 
 /// Build a funky rainbow-colored LayoutJob for the welcome text.
 fn welcome_text_job() -> egui::text::LayoutJob {
-    let mut job = egui::text::LayoutJob::default();
-    job.halign = egui::Align::Center;
+    let mut job = egui::text::LayoutJob { halign: egui::Align::Center, ..Default::default() };
 
     let text = "WELCOM TO GLOTTISDALE";
     let colors = [

--- a/crates/gui/src/editor/mod.rs
+++ b/crates/gui/src/editor/mod.rs
@@ -108,6 +108,7 @@ impl EditorState {
         self.arrangement.relayout(0.0);
     }
 
+    #[allow(dead_code)]
     /// Apply an effect to all selected clips.
     pub fn apply_effect_to_selected(&mut self, effect: ClipEffect) {
         let selected = &self.timeline.selected;


### PR DESCRIPTION
## Summary
- All 247 tests pass (`cargo test --workspace`)
- Zero clippy warnings (`cargo clippy --workspace -- -D warnings`)
- Updated README editor section: bank panel now documents ▶ play button for preview (replacing double-click), and playback section now mentions error display in toolbar
- Fixed all clippy warnings across the workspace (both playback-fix-related and pre-existing)

Fixes #48

## Test plan
- [x] `cargo test --workspace` — 247 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] README editor docs updated for playback error display and bank preview button

🤖 Generated with [Claude Code](https://claude.com/claude-code)