### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.wav
 glottisdale-output/
+.worktrees/
 
 # Rust
 target/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` to prevent git worktree contents from being tracked

## Test plan
- [x] Verify `.worktrees/` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)