### PR TITLE
docs: interactive syllable editor documentation and v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,13 @@ After running any pipeline, click **"Edit Arrangement"** to open the interactive
 
 The editor provides:
 
-- **Syllable bank** — all aligned syllables from your source audio, filterable, with waveform previews. Click to add to the timeline; each entry has a ▶ play button for quick preview.
-- **Timeline** — drag-to-reorder clips, zoom/pan (Ctrl+scroll / scroll), click to select, Shift+click for multi-select.
+- **Syllable bank** — all aligned syllables from your source audio, with waveform previews. Use the search field to filter by phoneme or word text. Click to add to the timeline; each entry has a ▶ play button for quick preview.
+- **Timeline** — drag-to-reorder clips, zoom/pan (Ctrl+scroll / scroll), click to select, Shift+click for multi-select. Clips display their waveform shape and phoneme label.
 - **Effects** — right-click any clip for stutter (x2-x8), time stretch (0.5x-4x), pitch shift (-12 to +12 semitones), duplicate, delete, and clear effects.
 - **Playback** — Play/Pause/Stop with a moving cursor. Plays from cursor position. Errors display as red text in the toolbar with a dismiss button.
 - **Export** — render the arrangement to a WAV file.
+
+**Keyboard shortcuts:** Space (play/pause), Ctrl+A (select all), Ctrl+scroll (zoom), scroll (pan).
 
 ## Dependencies
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -198,16 +198,20 @@ For the full technical breakdown of every step in the pipeline, see the [Archite
 
 If you are using the GUI (`glottisdale-gui`), you can open the interactive syllable editor after any pipeline finishes:
 
-1. **After a pipeline run** — click **"Edit Arrangement"** in the output section. This builds a syllable bank from the aligned source audio and opens the editor.
+1. **After a pipeline run** — click **"Edit Arrangement"** in the output section. This builds a syllable bank from the aligned source audio and opens the editor with the pipeline's arrangement pre-loaded on the timeline.
 2. **Blank canvas mode** — click **"Build Bank & Edit"** to run alignment only and open the editor with all syllables available but an empty timeline.
 
 In the editor:
 
-- **Add clips** from the syllable bank on the left (click to add, double-click to preview)
-- **Arrange** clips on the timeline by dragging to reorder
-- **Apply effects** by right-clicking a clip (stutter, time stretch, pitch shift, duplicate, delete)
-- **Play back** your arrangement with the Play button — the cursor tracks playback position
-- **Export** to a WAV file when you are happy with the result
+- **Browse the syllable bank** on the left panel — it lists all aligned syllables with waveform thumbnails. Use the search field at the top to filter by phoneme or source word. Each entry has a ▶ play button for quick preview.
+- **Add clips** to the timeline by clicking a bank entry, or drag it directly onto the timeline. The same syllable can be added multiple times.
+- **Arrange** clips on the timeline by dragging to reorder. Clips show their waveform shape and phoneme label (e.g. "HH AH0 L OW1").
+- **Apply effects** by right-clicking a clip — stutter (x2-x8), time stretch (0.5x-4x), pitch shift (-12 to +12 semitones), duplicate, delete, or clear all effects. Effects are non-destructive and can be removed at any time.
+- **Play back** your arrangement with the Play button — a red cursor tracks playback position in real time. Click anywhere on the timeline to set the cursor position. If playback fails, the error displays as red text in the toolbar.
+- **Zoom and pan** the timeline with Ctrl+scroll (zoom) and scroll (pan) to navigate longer arrangements.
+- **Export** to a WAV file when you are happy with the result.
+
+**Keyboard shortcuts:** Space (play/pause), Ctrl+A (select all), Shift+click (multi-select), Ctrl+scroll (zoom), scroll (pan).
 
 The editor is useful for fine-tuning collage output, building custom arrangements from scratch, or experimenting with individual syllable effects.
 


### PR DESCRIPTION
## Summary

- Expand interactive syllable editor documentation in README and quickstart guide
- Add keyboard shortcuts reference (Space, Ctrl+A, Ctrl+scroll, Shift+click)
- Document bank search/filter functionality and play-preview buttons
- Add detailed usage guidance for timeline clips, non-destructive effects, and playback error display

Fixes #32

**Note:** The core editor documentation (README section, architecture module map, quickstart editor section) was already added as part of the editor implementation PRs (#33, #40, #48). This PR closes #32 by adding the remaining practical details (keyboard shortcuts, search/filter, effect ranges) that were described in the design doc but not yet documented for end users. The version bump to 0.4.0 is no longer applicable — the workspace version has progressed to 0.5.1.

## Test plan

- [x] `cargo test --workspace` — 247 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Verify README editor section includes keyboard shortcuts
- [x] Verify quickstart editor section includes search/filter, preview, and shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)