### PR TITLE
chore: bump version to v0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/cli", "crates/gui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## Summary
- Bump version to v0.5.2 for release

Includes:
- Playback error surfacing (#43-#46)
- Bank preview button (#47)
- Clippy cleanup (#48)
- Editor docs (#32)
- Intel Mac build target

🤖 Generated with [Claude Code](https://claude.com/claude-code)