### PR TITLE
feat: scrubber drag and arrow key cursor movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,12 @@ After running any pipeline, click **"Edit Arrangement"** to open the interactive
 The editor provides:
 
 - **Syllable bank** — all aligned syllables from your source audio, with waveform previews. Use the search field to filter by phoneme or word text. Click to add to the timeline; each entry has a ▶ play button for quick preview.
-- **Timeline** — drag-to-reorder clips, zoom/pan (Ctrl+scroll / scroll), click to select, Shift+click for multi-select. Clips display their waveform shape and phoneme label.
+- **Timeline** — drag-to-reorder clips, zoom/pan (Ctrl+scroll / scroll), click to select, Shift+click for multi-select. Drag the red cursor handle or click empty space to reposition. Clips display their waveform shape and phoneme label.
 - **Effects** — right-click any clip for stutter (x2-x8), time stretch (0.5x-4x), pitch shift (-12 to +12 semitones), duplicate, delete, and clear effects.
 - **Playback** — Play/Pause/Stop with a moving cursor. Plays from cursor position. Errors display as red text in the toolbar with a dismiss button.
 - **Export** — render the arrangement to a WAV file.
 
-**Keyboard shortcuts:** Space (play/pause), Ctrl+A (select all), Ctrl+scroll (zoom), scroll (pan).
+**Keyboard shortcuts:** Space (play/pause), Left/Right arrows (move cursor), Shift+arrows (move cursor faster), Ctrl+A (select all), Ctrl+scroll (zoom), scroll (pan).
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- Scrubber/cursor can be dragged by clicking near the red line (8px grab zone) or on empty timeline space
- Triangle handle drawn at top of cursor for clear visual affordance
- Left/Right arrow keys move cursor (when timeline is hovered)
- Shift+Left/Right for 10x larger jumps
- Cursor highlights when being dragged

## Test plan
- [x] 248 workspace tests pass
- [x] Zero clippy warnings
- [ ] Manual: drag cursor handle to reposition
- [ ] Manual: drag on empty timeline space to scrub
- [ ] Manual: Left/Right arrow keys move cursor
- [ ] Manual: Shift+arrows for faster movement

🤖 Generated with [Claude Code](https://claude.com/claude-code)