### PR TITLE
chore: bump to 0.5.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/cli", "crates/gui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.16"
+version = "0.5.17"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
No-gaps shuffle.